### PR TITLE
T180745 - Parse and extract section name from edit summary

### DIFF
--- a/client/src/components/timeline/revision.js
+++ b/client/src/components/timeline/revision.js
@@ -7,12 +7,11 @@ import Wiki from 'app/entities/wiki';
 import Date from './date';
 import Timelapse from './timelapse';
 
-// eslint-disable-next-line no-useless-escape
-const REGEX_EDIT_SUMMARY_PARTS = /(?:\/\*([^\*]+)\*\/)?(.+)?/;
+const REGEX_EDIT_SUMMARY_PARTS = /(?:\/\*([^*]+)\*\/)?(.+)?/;
 
 // Append section name to the page title if it is included in the edit summary
 const getDisplayTitle = ( title, comment ) => {
-	const matches = REGEX_EDIT_SUMMARY_PARTS.exec( comment );
+	const matches = comment.match( REGEX_EDIT_SUMMARY_PARTS );
 
 	if ( matches[ 1 ] ) {
 		return title + ' § ' + matches[ 1 ].trim();
@@ -23,7 +22,7 @@ const getDisplayTitle = ( title, comment ) => {
 
 // Return edit summary without the section name if present
 const getDisplayComment = ( comment ) => {
-	let matches = REGEX_EDIT_SUMMARY_PARTS.exec( comment );
+	const matches = comment.match( REGEX_EDIT_SUMMARY_PARTS );
 
 	// return edit summary without section name or empty
 	if ( matches[ 2 ] ) {

--- a/client/src/components/timeline/revision.js
+++ b/client/src/components/timeline/revision.js
@@ -7,6 +7,32 @@ import Wiki from 'app/entities/wiki';
 import Date from './date';
 import Timelapse from './timelapse';
 
+// eslint-disable-next-line no-useless-escape
+const REGEX_EDIT_SUMMARY_PARTS = /(?:\/\*([^\*]+)\*\/)?(.+)?/;
+
+// Append section name to the page title if it is included in the edit summary
+const getDisplayTitle = ( title, comment ) => {
+	const matches = REGEX_EDIT_SUMMARY_PARTS.exec( comment );
+
+	if ( matches[ 1 ] ) {
+		return title + ' § ' + matches[ 1 ].trim();
+	}
+
+	return title;
+};
+
+// Return edit summary without the section name if present
+const getDisplayComment = ( comment ) => {
+	let matches = REGEX_EDIT_SUMMARY_PARTS.exec( comment );
+
+	// return edit summary without section name or empty
+	if ( matches[ 2 ] ) {
+		return matches[ 2 ].trim();
+	} else {
+		return '';
+	}
+};
+
 const Revision = ( { side, revision, date, duration, wiki } ) => {
 	let classes = [
 		'revision',
@@ -54,7 +80,7 @@ const Revision = ( { side, revision, date, duration, wiki } ) => {
 	}
 
 	const timestamp = moment( revision.timestamp, moment.ISO_8601 );
-	const revisionComment = revision.commenthidden ? <del><FormattedMessage id="revision-edit-summary-removed" /></del> : revision.comment;
+	const revisionComment = revision.commenthidden ? <del><FormattedMessage id="revision-edit-summary-removed" /></del> : getDisplayComment( revision.comment );
 
 	return (
 		<div className="row">
@@ -70,8 +96,8 @@ const Revision = ( { side, revision, date, duration, wiki } ) => {
 								<div className="record row justify-content-between">
 									<div className="col-xxl-1 col-xl-2 col-4 align-self-center timestamp">{timestamp.format( 'h:mma' )}</div>
 									<a href={url} className="col-xxl-11 col-xl-10 col-8 d-block content rounded pt-1 pb-1">
-										<span className="d-block title">{revision.title}</span>
-										<span className="d-block comment"><em>{revisionComment}</em></span>
+										<span className="d-block title">{getDisplayTitle( revision.title, revision.comment )}</span>
+										<span className="d-block comment"><em>{ revisionComment }</em></span>
 									</a>
 								</div>
 							</div>


### PR DESCRIPTION
When present, display section name from edit summary next to the
page title and remove it from the edit summary. If edit summary is
only the section name, do not display it