### PR TITLE
T186263 - Use toolforge image for composer container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,10 @@ services:
     command:
       - ./bin/watch
     volumes:
-      - ./:/code
+        - ./:/code:cached
   composer:
-    image: composer/composer:php5
-    command: install
+    image: docker-registry.tools.wmflabs.org/toollabs-php-web
+    command: composer install
+    working_dir: /server
     volumes:
-    - ./server:/app
+        - ./server:/server:cached


### PR DESCRIPTION
Use same image as production to run composer install