### PR TITLE
Disable autocompletion in the form

### DIFF
--- a/client/src/components/form.js
+++ b/client/src/components/form.js
@@ -5,7 +5,7 @@ import DateRangeContainer from 'app/components/fields/date-range.container';
 import Message from './i18n/message';
 
 const Form = () => (
-	<form>
+	<form autoComplete="off">
 		<div className="form-group row align-items-center">
 			<label className="col-sm-1 col col-form-label" htmlFor="users"><Message id="field-label-users" /></label>
 			<div className="col">


### PR DESCRIPTION
This disables the browser's autocompletion, which will clash with the live search. I still don't have InteractionTimeline working locally... not sure if I needed to rebuild the JS for this commit, or if that's done when deploying?