### PR TITLE
T190293 Update the Interaction Timeline UI to set a default start date

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-router-redux": "^5.0.0-alpha.8",
+    "react-router-redux": "^5.0.0-alpha.9",
     "react-select": "^1.0.0-rc.10",
     "react-with-styles": "^2.2.0",
     "reactstrap": "^5.0.0-beta.2",

--- a/client/src/actions/query.js
+++ b/client/src/actions/query.js
@@ -6,6 +6,14 @@ export const EVENTS = [
 	'QUERY_END_DATE_CHANGE'
 ];
 
+// Setting the default query is not a Query event that should be listened to.
+export function setDefaultQuery( query ) {
+	return {
+		type: 'QUERY_SET_DEFAULT',
+		query
+	};
+}
+
 export function updateQuery( query ) {
 	return {
 		type: 'QUERY_UPDATE',

--- a/client/src/epics/index.js
+++ b/client/src/epics/index.js
@@ -1,5 +1,5 @@
 import { combineEpics } from 'redux-observable';
-import { pushQueryToLocation, pushLocationToQuery, setDefaultQuery } from './query';
+import { pushQueryToLocation, pushLocationToQuery, setDefaultQueryOnLoad } from './query';
 import { fetchAllWikis, fetchWikiNamespaces } from './wiki';
 import {
 	shouldFetchRevisions,
@@ -19,5 +19,5 @@ export default combineEpics(
 	fetchRevision,
 	doFetchRevisions,
 	fetchDiff,
-	setDefaultQuery
+	setDefaultQueryOnLoad
 );

--- a/client/src/epics/index.js
+++ b/client/src/epics/index.js
@@ -1,5 +1,5 @@
 import { combineEpics } from 'redux-observable';
-import { pushQueryToLocation, pushLocationToQuery } from './query';
+import { pushQueryToLocation, pushLocationToQuery, setDefaultQuery } from './query';
 import { fetchAllWikis, fetchWikiNamespaces } from './wiki';
 import {
 	shouldFetchRevisions,
@@ -18,5 +18,6 @@ export default combineEpics(
 	revisionsReady,
 	fetchRevision,
 	doFetchRevisions,
-	fetchDiff
+	fetchDiff,
+	setDefaultQuery
 );

--- a/client/src/epics/query.js
+++ b/client/src/epics/query.js
@@ -41,12 +41,18 @@ export const pushQueryToLocation = ( action$, store ) => (
 
 export const setDefaultQueryOnLoad = ( action$, store ) => (
 	action$.ofType( LOCATION_CHANGE )
-		// Only set the default query on the initial localation change.
+		// Only set the default query on the initial location change.
 		.first()
 		// If the query is empty, set the default.
 		.filter( () => getQueryFromLocation( store.getState().router.location ).equals( new Query() ) )
 		// Do not update the URL on page load, wait for some other action.
-		.flatMap( () => Observable.of( setDefaultQuery( new Query( { startDate: moment.utc().startOf( 'day' ).subtract( 30, 'days' ).unix().toString() } ) ) ) )
+		.flatMap( () => {
+			const query = new Query( {
+				startDate: moment.utc().startOf( 'day' ).subtract( 30, 'days' ).unix().toString()
+			} );
+
+			return Observable.of( setDefaultQuery( query ) );
+		} )
 );
 
 export const pushLocationToQuery = ( action$, store ) => (

--- a/client/src/epics/query.js
+++ b/client/src/epics/query.js
@@ -1,13 +1,19 @@
 import { Observable } from 'rxjs';
 import qs from 'querystring';
+import moment from 'moment';
 import { replace, LOCATION_CHANGE } from 'react-router-redux';
 import getQueryFromLocation from 'app/utils/location-query';
-import { EVENTS as QUERY_EVENTS, updateQuery } from 'app/actions/query';
+import Query from 'app/entities/query';
+import { EVENTS as QUERY_EVENTS, updateQuery, startDateChange } from 'app/actions/query';
 
 export const pushQueryToLocation = ( action$, store ) => (
 	action$.filter( ( action ) => QUERY_EVENTS.includes( action.type ) )
 		// If there are no users and no search query, no action needs to be taken.
-		.filter( () => !getQueryFromLocation( store.getState().router.location ).equals( store.getState().query ) )
+		.filter( () => {
+			console.log( "LOCATIN QUERY", getQueryFromLocation( store.getState().router.location ).toJS() );
+			console.log( "STATE QUERY", store.getState().query.toJS() );
+			return !getQueryFromLocation( store.getState().router.location ).equals( store.getState().query );
+		} )
 		.flatMap( () => {
 			let location = store.getState().router.location;
 			let query = getQueryFromLocation( location );
@@ -23,7 +29,7 @@ export const pushQueryToLocation = ( action$, store ) => (
 
 			// Remove any keys that have empty values.
 			Object.keys( query ).forEach( ( key ) => {
-				if ( !query[ key ] ) {
+				if ( !query[ key ] || query[ key ].length === 0 ) {
 					delete query[ key ];
 				}
 			} );
@@ -33,8 +39,19 @@ export const pushQueryToLocation = ( action$, store ) => (
 				search: '?' + qs.stringify( query )
 			};
 
+			console.log( "LOCATION", replace( location ) );
+
 			return Observable.of( replace( location ) );
 		} )
+);
+
+export const setDefaultQuery = ( action$, store ) => (
+	action$.ofType( LOCATION_CHANGE )
+		// Only set the default query on the initial localation change.
+		.first()
+		// If the query is empty, set the default.
+		.filter( () => getQueryFromLocation( store.getState().router.location ).equals( new Query() ) )
+		.flatMap( () => Observable.of( startDateChange( moment.utc().startOf( 'day' ).subtract( 30, 'days' ).unix().toString() ) ) )
 );
 
 export const pushLocationToQuery = ( action$, store ) => (

--- a/client/src/reducers/query.js
+++ b/client/src/reducers/query.js
@@ -2,6 +2,7 @@ import Query from 'app/entities/query';
 
 export default ( state = new Query(), action ) => {
 	switch ( action.type ) {
+		case 'QUERY_SET_DEFAULT':
 		case 'QUERY_UPDATE':
 			let query = action.query;
 


### PR DESCRIPTION
Initially, I had this updating the URL on load, but I ran into ReactTraining/react-router#5790. I created a work around to not update the page on load, but I actually like the UX better. The URL updates with the default start date whenever you change any of the other form fields (or if you alter the start date to something other than blanking it out).