### PR TITLE
T190102 Fix the cldrpluralruleparser version

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "bootstrap": "^4.0.0-beta.2",
-    "cldrpluralruleparser": "^1.2.0",
+    "cldrpluralruleparser": "1.2.*",
     "clean-webpack-plugin": "^0.1.17",
     "css-loader": "^0.28.7",
     "dir-loader": "^0.3.0",


### PR DESCRIPTION
The tests are failing because of santhoshtr/CLDRPluralRuleParser#22, this PR downgrades the library and fixes the tests.