### PR TITLE
Change revision queries to use the new actor table/columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     before_install:
       - cd client
   - language: php
-    php: 5.6
+    php: 7.2
     before_install:
       - cp .env.dist .env
       - cd server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-registry.tools.wmflabs.org/toollabs-php-web
+FROM docker-registry.tools.wmflabs.org/toollabs-php72-web
 
 # Set the host domain on Linux.
 # see https://github.com/docker/for-linux/issues/264

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4152,7 +4152,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4170,11 +4171,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4187,15 +4190,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4298,7 +4304,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4308,6 +4315,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4320,17 +4328,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4347,6 +4358,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4419,7 +4431,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4429,6 +4442,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4504,7 +4518,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4534,6 +4549,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4551,6 +4567,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4589,11 +4606,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/server/src/Dao/RevisionDao.php
+++ b/server/src/Dao/RevisionDao.php
@@ -27,20 +27,21 @@ class RevisionDao extends AbstractDao {
 		$searchColumn = $this->getUserSearchColumn( $users );
 		$query->select( 'rev_id' )
 			->from( 'revision_userindex', 'r' )
+			->join( 'r', 'actor', 'a', 'r.rev_actor = a.actor_id' )
 			->where( $searchColumn . ' in (:users)' )
-			->andWhere( 'rev_page in (:pages)' )
-			->orderBy( 'rev_id', 'asc' )
+			->andWhere( 'r.rev_page in (:pages)' )
+			->orderBy( 'r.rev_id', 'asc' )
 			->setMaxResults( $limit )
 			->setParameter( ':users', $users, Connection::PARAM_STR_ARRAY )
 			->setParameter( ':pages', $pages, Connection::PARAM_STR_ARRAY );
 
 		if ( $startDate ) {
-			$query->andWhere( 'rev_timestamp >= :start_date' )
+			$query->andWhere( 'r.rev_timestamp >= :start_date' )
 				->setParameter( ':start_date', $startDate->format( 'YmdHis' ) );
 		}
 
 		if ( $endDate ) {
-			$query->andWhere( 'rev_timestamp <= :end_date' )
+			$query->andWhere( 'r.rev_timestamp <= :end_date' )
 				->setParameter( ':end_date', $endDate->format( 'YmdHis' ) );
 		}
 		$this->logger->debug( sprintf( "Fetching revisions for users: %s", join( ', ', $users ) ) );
@@ -61,20 +62,21 @@ class RevisionDao extends AbstractDao {
 	) {
 		$query = $this->conn->createQueryBuilder();
 		$searchColumn = $this->getUserSearchColumn( $users );
-		$query->select( 'rev_page' )
-			->from( 'revision_userindex' )
+		$query->select( 'r.rev_page' )
+			->from( 'revision_userindex', 'r' )
+			->join( 'r', 'actor', 'a', 'r.rev_actor = a.actor_id' )
 			->where( $searchColumn . ' in (:users)' )
-			->groupBy( 'rev_page' )
+			->groupBy( 'r.rev_page' )
 			->having( 'count(distinct ' . $searchColumn . ') > 1' )
 			->setParameter( ':users', $users, Connection::PARAM_STR_ARRAY );
 
 		if ( $startDate ) {
-			$query->andWhere( 'rev_timestamp >= :start_date' )
+			$query->andWhere( 'r.rev_timestamp >= :start_date' )
 				->setParameter( ':start_date', $startDate->format( 'YmdHis' ) );
 		}
 
 		if ( $endDate ) {
-			$query->andWhere( 'rev_timestamp <= :end_date' )
+			$query->andWhere( 'r.rev_timestamp <= :end_date' )
 				->setParameter( ':end_date', $endDate->format( 'YmdHis' ) );
 		}
 
@@ -94,7 +96,7 @@ class RevisionDao extends AbstractDao {
 			'r.rev_page',
 			'page_namespace',
 			'page_title',
-			'r.rev_user_text',
+			'a.actor_name',
 			'r.rev_timestamp',
 			'r.rev_minor_edit',
 			'r.rev_len',
@@ -104,7 +106,8 @@ class RevisionDao extends AbstractDao {
 		];
 		$query->select( $fields )
 			->from( 'revision_userindex', 'r' )
-			->join( 'r', 'page', 'p', 'r.rev_page = page_id' )
+			->join( 'r', 'page', 'p', 'r.rev_page = p.page_id' )
+			->join( 'r', 'actor', 'a', 'r.rev_actor = a.actor_id' )
 			->leftJoin( 'r', 'comment', 'c', 'r.rev_comment_id = c.comment_id' )
 			->leftJoin( 'r', 'revision_userindex', 'r2', 'r.rev_parent_id = r2.rev_id' )
 			->where( 'r.rev_id in (:rev_ids)' )
@@ -124,9 +127,9 @@ class RevisionDao extends AbstractDao {
 	 * @return string
 	 */
 	private function getUserSearchColumn( array $users ) {
-		$column = 'rev_user_text';
+		$column = 'a.actor_name';
 		if ( $this->isNumericArray( $users ) ) {
-			$column = 'rev_user';
+			$column = 'a.actor_user';
 		}
 
 		return $column;

--- a/server/src/Service/InteractionService.php
+++ b/server/src/Service/InteractionService.php
@@ -80,7 +80,7 @@ class InteractionService {
 				'page_id' => (int)$revision['rev_page'],
 				'page_title' => $this->buildTitle( $revision['page_title'] ),
 				'page_namespace' => (int)$revision['page_namespace'],
-				'user' => $revision['rev_user_text'],
+				'user' => $revision['actor_name'],
 				'timestamp' => strtotime( $revision['rev_timestamp'] ),
 				'minor' => !!$revision['rev_minor_edit'],
 				'size_diff' => (int)$revision['sizediff'],

--- a/server/tests/Service/InteractionServiceTest.php
+++ b/server/tests/Service/InteractionServiceTest.php
@@ -91,7 +91,7 @@ class InteractionServiceTest extends TestCase {
 				'rev_page' => '1',
 				'page_title' => 'title 1',
 				'page_namespace' => '1',
-				'rev_user_text' => 'user 1',
+				'actor_name' => 'user 1',
 				'rev_timestamp' => '20180222000000',
 				'rev_minor_edit' => 1,
 				'sizediff' => 100,


### PR DESCRIPTION
I'm not  sure we still need to use the revision_userindex but https://wikitech.wikimedia.org/wiki/Help:Toolforge/Database has not been updated to reflect the actors table or if there is any other optimized table view with the new revision/actor/user relationship.

This should do it for now.

Bug: T224613