### PR TITLE
Add a simple warning for users without JavaScript

### DIFF
--- a/client/index.ejs
+++ b/client/index.ejs
@@ -19,7 +19,7 @@
 		<div id="root"></div>
 		<noscript>
 			<p>
-			    This tool requires JavaScript to function. If you do not want to enable Javascript, you will continue to be unable to use this tool.
+			    This tool requires JavaScript to function.
 				<img src="https://piwik.wikimedia.org/piwik.php?idsite=14" style="border:0;" alt="" />
 			</p>
 		</noscript>

--- a/client/index.ejs
+++ b/client/index.ejs
@@ -19,6 +19,7 @@
 		<div id="root"></div>
 		<noscript>
 			<p>
+			    This tool requires JavaScript to function. If you do not want to enable Javascript, you will continue to be unable to use this tool.
 				<img src="https://piwik.wikimedia.org/piwik.php?idsite=14" style="border:0;" alt="" />
 			</p>
 		</noscript>


### PR DESCRIPTION
We can make this fancier, but this is just to have something simple
until we can design a nicer look. This avoids the blank white page
that a no JS user currently receives.

Clearly, this is English-only. Think incrementalism.

Bug: T185785