### PR TITLE
Fix spelling of exported module

### DIFF
--- a/client/src/components/timeline/user-list.js
+++ b/client/src/components/timeline/user-list.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Set } from 'immutable';
-import UserContaienr from './user.container';
+import UserContainer from './user.container';
 
 const UserList = ( { users } ) => (
 	users.map( ( user ) => (
-		<UserContaienr key={user} user={user} />
+		<UserContainer key={user} user={user} />
 	) ).toArray()
 );
 


### PR DESCRIPTION
This should be a no-op change that fixes a simple typo.