### PR TITLE
Make revision link more discoverable and less clicky

### DIFF
--- a/client/src/components/timeline/diff/header-revision.js
+++ b/client/src/components/timeline/diff/header-revision.js
@@ -50,11 +50,11 @@ class HeaderRevision extends React.PureComponent {
 
 		return (
 			<Header href={this.props.url} side={this.props.side} className="text-center">
-				{this.props.revision.user}<br />
-				{this.props.revision.timestamp.format( 'YYYY-MM-DD' )} &mdash; {this.props.revision.timestamp.format( 'HH:mm' )}
 				<Link href={this.props.url} className="text-right">
 					<i className="mr-2 material-icons">restore</i>
 				</Link>
+				{this.props.revision.user}<br />
+				{this.props.revision.timestamp.format( 'YYYY-MM-DD' )} &mdash; {this.props.revision.timestamp.format( 'HH:mm' )}
 			</Header>
 		);
 	}

--- a/client/src/components/timeline/diff/header-revision.js
+++ b/client/src/components/timeline/diff/header-revision.js
@@ -50,7 +50,7 @@ class HeaderRevision extends React.PureComponent {
 
 		return (
 			<Header href={this.props.url} side={this.props.side} className="text-center">
-				<Link href={this.props.url} className="text-right">
+				<Link href={this.props.url}>
 					<i className="mr-2 material-icons">restore</i>
 				</Link>
 				{this.props.revision.user}<br />

--- a/client/src/components/timeline/diff/header-revision.js
+++ b/client/src/components/timeline/diff/header-revision.js
@@ -4,6 +4,7 @@ import { Message } from '@wikimedia/react.i18n';
 import RevisionEntity from 'app/entities/revision';
 import Header from 'app/components/timeline/header';
 import Spinner from 'app/components/timeline/spinner';
+import Link from 'app/components/link';
 
 class HeaderRevision extends React.PureComponent {
 
@@ -51,6 +52,9 @@ class HeaderRevision extends React.PureComponent {
 			<Header href={this.props.url} side={this.props.side} className="text-center">
 				{this.props.revision.user}<br />
 				{this.props.revision.timestamp.format( 'YYYY-MM-DD' )} &mdash; {this.props.revision.timestamp.format( 'HH:mm' )}
+				<Link href={this.props.url} className="text-right">
+					<i className="mr-2 material-icons">restore</i>
+				</Link>
 			</Header>
 		);
 	}

--- a/client/src/components/timeline/header.js
+++ b/client/src/components/timeline/header.js
@@ -36,15 +36,13 @@ const Header = ( { children, className, side } ) => {
 Header.propTypes = {
 	children: PropTypes.node,
 	side: PropTypes.string,
-	className: PropTypes.string,
-	href: PropTypes.string
+	className: PropTypes.string
 };
 
 Header.defaultProps = {
 	children: undefined,
 	side: undefined,
-	className: '',
-	href: undefined
+	className: ''
 };
 
 export default Header;

--- a/client/src/components/timeline/header.js
+++ b/client/src/components/timeline/header.js
@@ -28,9 +28,9 @@ const Header = ( { children, href, className, side } ) => {
 	}
 
 	return (
-		<Link href={href} className={className.join( ' ' )}>
+		<div className={className.join( ' ' )}>
 			{children}
-		</Link>
+		</div>
 	);
 };
 

--- a/client/src/components/timeline/header.js
+++ b/client/src/components/timeline/header.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Link from 'app/components/link';
 
-const Header = ( { children, href, className, side } ) => {
+const Header = ( { children, className, side } ) => {
 	if ( !children ) {
 		return (
 			<div className="col-6" />

--- a/client/src/components/timeline/user.js
+++ b/client/src/components/timeline/user.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Wiki from 'app/entities/wiki';
 import 'material-design-icons/iconfont/material-icons.css';
 import Header from './header';
+import Link from 'app/components/link';
 
 const User = ( { user, side, wiki } ) => {
 	if ( !user ) {
@@ -18,7 +19,9 @@ const User = ( { user, side, wiki } ) => {
 
 	return (
 		<Header href={href} className="rounded" side={side}>
-			<i className="mr-2 material-icons">person</i>
+			<Link href={href}>
+				<i className="mr-2 material-icons">person</i>
+			</Link>
 			<span>{user}</span>
 		</Header>
 	);

--- a/client/src/components/timeline/user.js
+++ b/client/src/components/timeline/user.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Wiki from 'app/entities/wiki';
+import Link from 'app/components/link';
 import 'material-design-icons/iconfont/material-icons.css';
 import Header from './header';
-import Link from 'app/components/link';
 
 const User = ( { user, side, wiki } ) => {
 	if ( !user ) {


### PR DESCRIPTION
Previously, the entire header was a giant link. This removes the
link functionality. I've added back an icon that links to the revision
but I didn't do something similar for the user. We can add that back
in a future patch.

I expect there to be opinions about the icon and its placement.

Bug: T194439