### PR TITLE
Use the font stack from wikimedia-ui-base

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
     "style-loader": "^0.19.0",
     "uglifyjs-webpack-plugin": "^1.0.1",
     "webpack": "^3.8.1",
-    "wikimedia-ui-base": "^0.10.0"
+    "wikimedia-ui-base": "^0.14.0"
   },
   "devDependencies": {
     "babel-jest": "^23.2.0",

--- a/client/styles/styles.scss
+++ b/client/styles/styles.scss
@@ -1,8 +1,8 @@
 $font-size-base: 0.9rem;
-$font-family-sans-serif: 'Lato', sans-serif;
 
 // TODO Should be wmui-color-accent50, but ligthen/darken doesn't work on vars
 $primary: #36c;
+$font-family-sans-serif: var(--font-family-system-sans);
 
 @import "~wikimedia-ui-base/wikimedia-ui-base";
 @import "~bootstrap/scss/_functions";


### PR DESCRIPTION
Also update to the newest version of that package (`0.14.01).

## Before
<img width="634" alt="Screenshot 2019-08-15 at 5 07 45 PM" src="https://user-images.githubusercontent.com/9491/63092404-47ed5a00-bf7f-11e9-9eaa-df3bc7791bbe.png">

## After
<img width="672" alt="Screenshot 2019-08-15 at 5 07 57 PM" src="https://user-images.githubusercontent.com/9491/63092406-4b80e100-bf7f-11e9-8b08-b07b49ef534e.png">

