### PR TITLE
Correct spelling/usage from Chronologic to Chronological

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,5 +1,5 @@
 {
-		"app-description": "Chronologic history for two users on pages where they have both made edits.",
+		"app-description": "Chronological history for two users on pages where they have both made edits.",
 		"app-feedback-link": "Help",
 		"app-title": "Interaction Timeline",
 		"back-top": "Back to Top",


### PR DESCRIPTION
This shouldn't change the need for translations. I looked it up
and it would appear that Chronologic is considered an obsolete
usage.