### PR TITLE
resolve: WARNING: The TCP backlog setting of 511 cannot be enfo…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,5 @@ services:
       - ./:/code:cached
   redis:
     image: redis
+    sysctls:
+      net.core.somaxconn: 511


### PR DESCRIPTION
Resolve warning:
```
WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
```
per [WARNING: /proc/sys/net/core/somaxconn is set to the lower value of 128. · Issue #35 · docker-library/redis](https://github.com/docker-library/redis/issues/35)